### PR TITLE
Fix TransactionMapper to ignore 'line' elements that are not actually transaction lines

### DIFF
--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\Mappers;
 
+use DOMXPath;
 use Money\Currency;
 use Money\Money;
 use PhpTwinfield\BaseTransaction;
@@ -134,7 +135,7 @@ class TransactionMapper
         // Parse the transaction lines
         $transactionLineClassName = $transaction->getLineClassName();
 
-        foreach ($transactionElement->getElementsByTagName('line') as $lineElement) {
+        foreach ((new DOMXPath($document))->query('/transaction/lines/line') as $lineElement) {
             self::checkForMessage($transaction, $lineElement);
 
             /** @var BaseTransactionLine $transactionLine */


### PR DESCRIPTION
Mirror of php-twinfield#186